### PR TITLE
Add truncating method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,14 @@ pub fn challenge_hash(
         h,
     ]);
 
-    // NOTE: 250 is used, instead of 251, as even numbers allow us to 
-    // perform bitwise operations in circuit. 
+    // NOTE: 250 is used, instead of 251, as even numbers allow us to
+    // perform bitwise operations in circuit.
     let c_hash = c_hash & BlsScalar::pow_of_2(250).sub(&BlsScalar::one());
-    
+
     // NOTE: This should never fail as we are truncating the BLS scalar
-    // to be less than the JubJub modulus. 
-    JubJubScalar::from_bytes(&c_hash.to_bytes()).unwrap()
+    // to be less than the JubJub modulus.
+    Option::from(JubJubScalar::from_bytes(&c_hash.to_bytes()))
+        .expect("Failed to truncate BlsScalar")
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
A method to truncate BlsScalars to the JubJub scalar field is added to allow for in circuit constraining.

This closes #3 