### PR TITLE
To from bytes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     /// Invalid signature
     InvalidSignature,
     /// Serialisation error
-    SerialisationError
+    SerialisationError,
 }
 
 #[cfg(feature = "std")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     InvalidData,
     /// Invalid signature
     InvalidSignature,
+    /// Serialisation error
+    SerialisationError
 }
 
 #[cfg(feature = "std")]

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -6,11 +6,13 @@
 
 #![allow(non_snake_case)]
 
+#[allow(unused_imports)]
 use crate::error::Error;
 #[cfg(feature = "canon")]
 use canonical::Canon;
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
+#[allow(unused_imports)]
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{
     JubJubExtended, JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
@@ -18,7 +20,9 @@ use dusk_jubjub::{
 #[cfg(feature = "std")]
 use poseidon252::sponge::sponge::sponge_hash;
 use rand::Rng;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
+#[cfg(feature = "std")]
+use rand_core::RngCore;
 
 /// Method to create a challenge hash for signature scheme
 #[cfg(feature = "std")]

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -4,12 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![allow(non_snake_case)]
 use crate::error::Error;
 #[cfg(feature = "canon")]
 use canonical::Canon;
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
+#[cfg(feature = "std")]
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{
     JubJubAffine, JubJubExtended, JubJubScalar, GENERATOR_EXTENDED,
@@ -17,8 +17,11 @@ use dusk_jubjub::{
 #[cfg(feature = "std")]
 use poseidon252::sponge::sponge::sponge_hash;
 use rand::Rng;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
+#[cfg(feature = "std")]
+use rand_core::RngCore;
 
+#[allow(non_snake_case)]
 #[cfg(feature = "std")]
 /// Method to create a challenge hash for signature scheme
 pub fn challenge_hash(R: JubJubExtended, message: BlsScalar) -> JubJubScalar {
@@ -37,6 +40,7 @@ pub fn challenge_hash(R: JubJubExtended, message: BlsScalar) -> JubJubScalar {
         .expect("Failed to truncate BlsScalar")
 }
 
+#[allow(non_snake_case)]
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 pub struct SecretKey(JubJubScalar);
@@ -55,7 +59,7 @@ impl SecretKey {
 
     pub fn to_bytes(&self) -> [u8; 32] {
         let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&self.0.to_bytes()[..]);
+        bytes.copy_from_slice(&self.0.to_bytes());
         bytes
     }
 
@@ -66,6 +70,7 @@ impl SecretKey {
         }
     }
 
+    #[allow(non_snake_case)]
     #[cfg(feature = "std")]
     // Signs a chosen message with a given secret key
     // using the dusk variant of the Schnorr signature scheme.
@@ -117,6 +122,7 @@ impl PublicKey {
 
 /// An Schnorr signature, produced by signing a message with a
 /// [`SecretKey`].
+#[allow(non_snake_case)]
 #[derive(PartialEq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 pub struct Signature {

--- a/tests/single_key_tests.rs
+++ b/tests/single_key_tests.rs
@@ -36,3 +36,15 @@ fn test_wrong_keys() {
 
     assert!(b.is_err());
 }
+
+#[test]
+fn to_from_bytes() {
+    let sk = SecretKey::new(&mut rand::thread_rng());
+    assert_eq!(sk, SecretKey::from_bytes(&sk.to_bytes()).unwrap());
+    let message = BlsScalar::random(&mut rand::thread_rng());
+    let pk = PublicKey::from(&sk);
+    assert_eq!(pk, PublicKey::from_bytes(&pk.to_bytes()).unwrap());
+    let sig = sk.sign(&mut rand::thread_rng(), message);
+    use schnorr::single_key::Signature;
+    assert_eq!(sig, Signature::from_bytes(&sig.to_bytes()).unwrap());
+}


### PR DESCRIPTION
Now `PublicKey`, `PrivateKey` and `Signature` implement
to and from_bytes which is needed so that we can pass
the structures through FFI without needing to use raw pointers.