### PR TITLE
Expose inner attributes of signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schnorr"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Luke Pearson <luke@dusk.network>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,27 @@ version = "0.1.0"
 authors = ["Luke Pearson <luke@dusk.network>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-poseidon252 = { git = "https://github.com/dusk-network/Poseidon252", tag = "v0.14.0", optional = true}
-rand = {version = "0.7.0", default-features = false}
-thiserror = "1.0"
+rand_core = "0.5"
+poseidon252 = {git="https://github.com/dusk-network/Poseidon252", tag="v0.15.0", default-features=false}
 dusk-bls12_381 = {version = "0.3", default-features = false}
 dusk-jubjub = {version = "0.5", default-features = false}
-rand_core = "0.5.1"
 canonical = {version = "0.4", optional = true}
 canonical_derive = {version = "0.4", optional = true}
 
+[dev-dependencies]
+rand = "0.7"
+
 [features]
 default = ["std"]
-std = ["rand/default", "dusk-bls12_381/default", "dusk-jubjub/default", "poseidon252/default"]
-canon = ["canonical", "canonical_derive", "dusk-bls12_381/canon", "dusk-jubjub/canon"]
-
+std = [
+    "dusk-bls12_381/default",
+    "dusk-jubjub/default",
+    "poseidon252/default"
+]
+canon = [
+    "canonical",
+    "canonical_derive",
+    "dusk-bls12_381/canon",
+    "dusk-jubjub/canon"
+]

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -17,25 +17,20 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{
     JubJubExtended, JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
 };
-#[cfg(feature = "std")]
-use poseidon252::sponge::sponge::sponge_hash;
-use rand::Rng;
-use rand_core::CryptoRng;
-#[cfg(feature = "std")]
-use rand_core::RngCore;
+use poseidon252::sponge::hash;
+use rand_core::{CryptoRng, RngCore};
 
 /// Method to create a challenge hash for signature scheme
-#[cfg(feature = "std")]
 pub fn challenge_hash(
     R: JubJubExtended,
     R_prime: JubJubExtended,
     message: BlsScalar,
 ) -> JubJubScalar {
-    let h = sponge_hash(&[message]);
+    let h = hash(&[message]);
     let R_scalar = R.to_hash_inputs();
     let R_prime_scalar = R_prime.to_hash_inputs();
 
-    let c_hash = sponge_hash(&[
+    let c_hash = hash(&[
         R_scalar[0],
         R_scalar[1],
         R_prime_scalar[0],
@@ -80,7 +75,7 @@ impl SecretKey {
     /// of the Field JubJubScalar.
     pub fn new<T>(rand: &mut T) -> SecretKey
     where
-        T: Rng + CryptoRng,
+        T: RngCore + CryptoRng,
     {
         let fr = JubJubScalar::random(rand);
 
@@ -89,7 +84,6 @@ impl SecretKey {
 
     // Signs a chosen message with a given secret key
     // using the dusk variant of the Schnorr signature scheme.
-    #[cfg(feature = "std")]
     pub fn sign<R>(&self, rng: &mut R, message: BlsScalar) -> Signature
     where
         R: RngCore + CryptoRng,
@@ -161,7 +155,6 @@ impl Signature {
 
     /// Function to verify that two given point in a Schnorr signature
     /// have the same DLP
-    #[cfg(feature = "std")]
     pub fn verify(
         &self,
         public_key_pair: &PublicKeyPair,

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -57,6 +57,24 @@ pub fn challenge_hash(
 #[cfg_attr(feature = "canon", derive(Canon))]
 pub struct SecretKey(JubJubScalar);
 
+impl From<JubJubScalar> for SecretKey {
+    fn from(s: JubJubScalar) -> SecretKey {
+        SecretKey(s)
+    }
+}
+
+impl From<&JubJubScalar> for SecretKey {
+    fn from(s: &JubJubScalar) -> SecretKey {
+        SecretKey(*s)
+    }
+}
+
+impl AsRef<JubJubScalar> for SecretKey {
+    fn as_ref(&self) -> &JubJubScalar {
+        &self.0
+    }
+}
+
 impl SecretKey {
     /// This will create a new [`SecretKey`] from a scalar
     /// of the Field JubJubScalar.
@@ -126,6 +144,21 @@ pub struct Signature {
 }
 
 impl Signature {
+    #[allow(non_snake_case)]
+    pub fn U(&self) -> &JubJubScalar {
+        &self.U
+    }
+
+    #[allow(non_snake_case)]
+    pub fn R(&self) -> &JubJubExtended {
+        &self.R
+    }
+
+    #[allow(non_snake_case)]
+    pub fn R_prime(&self) -> &JubJubExtended {
+        &self.R_prime
+    }
+
     /// Function to verify that two given point in a Schnorr signature
     /// have the same DLP
     #[cfg(feature = "std")]

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -46,14 +46,20 @@ pub fn challenge_hash(R: JubJubExtended, message: BlsScalar) -> JubJubScalar {
 pub struct SecretKey(JubJubScalar);
 
 impl From<JubJubScalar> for SecretKey {
-    fn from(_scalar: JubJubScalar) -> SecretKey {
-        SecretKey(_scalar)
+    fn from(s: JubJubScalar) -> SecretKey {
+        SecretKey(s)
     }
 }
 
 impl From<&JubJubScalar> for SecretKey {
-    fn from(_scalar: &JubJubScalar) -> SecretKey {
-        SecretKey(*_scalar)
+    fn from(s: &JubJubScalar) -> SecretKey {
+        SecretKey(*s)
+    }
+}
+
+impl AsRef<JubJubScalar> for SecretKey {
+    fn as_ref(&self) -> &JubJubScalar {
+        &self.0
     }
 }
 
@@ -120,14 +126,20 @@ impl From<&SecretKey> for PublicKey {
 }
 
 impl From<JubJubExtended> for PublicKey {
-    fn from(_point: JubJubExtended) -> PublicKey {
-        PublicKey(_point)
+    fn from(p: JubJubExtended) -> PublicKey {
+        PublicKey(p)
     }
 }
 
 impl From<&JubJubExtended> for PublicKey {
-    fn from(_point: &JubJubExtended) -> PublicKey {
-        PublicKey(*_point)
+    fn from(p: &JubJubExtended) -> PublicKey {
+        PublicKey(*p)
+    }
+}
+
+impl AsRef<JubJubExtended> for PublicKey {
+    fn as_ref(&self) -> &JubJubExtended {
+        &self.0
     }
 }
 
@@ -155,6 +167,16 @@ pub struct Signature {
 }
 
 impl Signature {
+    #[allow(non_snake_case)]
+    pub fn U(&self) -> &JubJubScalar {
+        &self.U
+    }
+
+    #[allow(non_snake_case)]
+    pub fn R(&self) -> &JubJubExtended {
+        &self.R
+    }
+
     pub fn to_bytes(&self) -> [u8; 64] {
         let mut arr = [0u8; 64];
         arr[0..32].copy_from_slice(&self.U.to_bytes()[..]);

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -9,26 +9,20 @@ use crate::error::Error;
 use canonical::Canon;
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
-#[cfg(feature = "std")]
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{
     JubJubAffine, JubJubExtended, JubJubScalar, GENERATOR_EXTENDED,
 };
-#[cfg(feature = "std")]
-use poseidon252::sponge::sponge::sponge_hash;
-use rand::Rng;
-use rand_core::CryptoRng;
-#[cfg(feature = "std")]
-use rand_core::RngCore;
+use poseidon252::sponge::hash;
+use rand_core::{CryptoRng, RngCore};
 
 #[allow(non_snake_case)]
-#[cfg(feature = "std")]
 /// Method to create a challenge hash for signature scheme
 pub fn challenge_hash(R: JubJubExtended, message: BlsScalar) -> JubJubScalar {
-    let h = sponge_hash(&[message]);
+    let h = hash(&[message]);
     let R_scalar = R.to_hash_inputs();
 
-    let c_hash = sponge_hash(&[R_scalar[0], R_scalar[1], h]);
+    let c_hash = hash(&[R_scalar[0], R_scalar[1], h]);
 
     // NOTE: 251 is used, instead of 252, as truncating to even numbers allow us
     // to align with the perform bitwise operations in circuit.
@@ -68,7 +62,7 @@ impl SecretKey {
     /// of the Field JubJubScalar.
     pub fn new<T>(rand: &mut T) -> SecretKey
     where
-        T: Rng + CryptoRng,
+        T: RngCore + CryptoRng,
     {
         let fr = JubJubScalar::random(rand);
 
@@ -89,7 +83,6 @@ impl SecretKey {
     }
 
     #[allow(non_snake_case)]
-    #[cfg(feature = "std")]
     // Signs a chosen message with a given secret key
     // using the dusk variant of the Schnorr signature scheme.
     pub fn sign<R>(&self, rng: &mut R, message: BlsScalar) -> Signature
@@ -205,7 +198,6 @@ impl Signature {
         }
     }
 
-    #[cfg(feature = "std")]
     /// Function to verify that a given point in a Schnorr signature
     /// have the same DLP
     pub fn verify(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod error;
 mod key_variants;
 

--- a/tests/double_key_tests.rs
+++ b/tests/double_key_tests.rs
@@ -4,7 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![cfg(feature = "std")]
 use dusk_bls12_381::BlsScalar;
 use schnorr::double_key::{PublicKeyPair, SecretKey};
 

--- a/tests/single_key_tests.rs
+++ b/tests/single_key_tests.rs
@@ -4,7 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![cfg(feature = "std")]
 use dusk_bls12_381::BlsScalar;
 use schnorr::single_key::{PublicKey, SecretKey};
 


### PR DESCRIPTION
Some functionalities such as ZK circuits uses the internal attributes of the Schnorr signatures. Hence, these must be exposed as API