### PR TITLE
Methods name convention and public key attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `PublicKeyPair` attributes R and R_prime exposed as methods
-- `Proof::keys` added to fetch `PublicKeyPair::public`
+- `Proof::keys` added to fetch `PublicKeyPair`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `PublicKeyPair` attributes R and R_prime exposed as methods
+- `Proof::keys` added to fetch `PublicKeyPair::public`
 
 ### Changed
 
-- `PublicKeyPair::R` renamed to `PublicKeyPair::public`
 - JubJubScalars renamed from `U` to `u`, as in notation standards
 
 ## [0.3.0] - 2021-01-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2021-01-29
+
+### Added
+
+- `PublicKeyPair` attributes R and R_prime exposed as methods
+
+### Changed
+
+- `PublicKeyPair::R` renamed to `PublicKeyPair::public`
+- JubJubScalars renamed from `U` to `u`, as in notation standards
+
 ## [0.3.0] - 2021-01-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schnorr"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>"]
 edition = "2018"
 

--- a/src/gadgets/tests/helpers.rs
+++ b/src/gadgets/tests/helpers.rs
@@ -102,11 +102,11 @@ impl Circuit<'_> for DoubleKeyCircuit {
     fn gadget(&mut self, composer: &mut StandardComposer) -> Result<()> {
         let R = Point::from_private_affine(
             composer,
-            (self.proof.R().0).0.as_ref().into(),
+            self.proof.public().R().as_ref().into(),
         );
         let R_prime = Point::from_private_affine(
             composer,
-            (self.proof.R().0).1.as_ref().into(),
+            self.proof.public().R_prime().as_ref().into(),
         );
         let u = composer.add_input(self.proof.u().clone().into());
         let PK = Point::from_private_affine(

--- a/src/gadgets/tests/helpers.rs
+++ b/src/gadgets/tests/helpers.rs
@@ -102,11 +102,11 @@ impl Circuit<'_> for DoubleKeyCircuit {
     fn gadget(&mut self, composer: &mut StandardComposer) -> Result<()> {
         let R = Point::from_private_affine(
             composer,
-            self.proof.public().R().as_ref().into(),
+            self.proof.keys().R().as_ref().into(),
         );
         let R_prime = Point::from_private_affine(
             composer,
-            self.proof.public().R_prime().as_ref().into(),
+            self.proof.keys().R_prime().as_ref().into(),
         );
         let u = composer.add_input(self.proof.u().clone().into());
         let PK = Point::from_private_affine(

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -41,6 +41,18 @@ fn challenge_hash(R: PublicKeyPair, message: BlsScalar) -> JubJubScalar {
 /// Structure repesenting a pair of [`PublicKey`] generated from a [`SecretKey`]
 pub struct PublicKeyPair(pub(crate) (PublicKey, PublicKey));
 
+impl PublicKeyPair {
+    /// R ecc generator point
+    pub fn R(&self) -> &PublicKey {
+        &self.0 .0
+    }
+
+    /// R ecc generator nums point
+    pub fn R_prime(&self) -> &PublicKey {
+        &self.0 .1
+    }
+}
+
 impl From<&SecretKey> for PublicKeyPair {
     fn from(sk: &SecretKey) -> Self {
         let public_key = PublicKey::from(sk);
@@ -78,19 +90,17 @@ impl Serializable<64> for PublicKeyPair {
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 pub struct Proof {
-    U: JubJubScalar,
-    R: PublicKeyPair,
+    u: JubJubScalar,
+    public: PublicKeyPair,
 }
 
 impl Proof {
-    #[allow(non_snake_case)]
     pub fn u(&self) -> &JubJubScalar {
-        &self.U
+        &self.u
     }
 
-    #[allow(non_snake_case)]
-    pub fn R(&self) -> &PublicKeyPair {
-        &self.R
+    pub fn public(&self) -> &PublicKeyPair {
+        &self.public
     }
 
     /// An Schnorr signature, produced by signing a message with a
@@ -109,15 +119,15 @@ impl Proof {
         // R_prime = r * G_NUM
         let R = GENERATOR_EXTENDED * r;
         let R_prime = GENERATOR_NUMS_EXTENDED * r;
-        let pair =
+        let public =
             PublicKeyPair((PublicKey::from(R), PublicKey::from(R_prime)));
         // Compute challenge value, c = H(R||R_prime||H(m));
-        let c = challenge_hash(pair, message);
+        let c = challenge_hash(public, message);
 
         // Compute scalar signature, U = r - c * sk,
-        let U = r - (c * sk.as_ref());
+        let u = r - (c * sk.as_ref());
 
-        Self { U, R: pair }
+        Self { u, public }
     }
 
     /// Function to verify that two given point in a Schnorr signature
@@ -128,17 +138,18 @@ impl Proof {
         message: BlsScalar,
     ) -> bool {
         // Compute challenge value, c = H(R||R_prime||H(m));
-        let c = challenge_hash(self.R, message);
+        let c = challenge_hash(self.public, message);
 
         // Compute verification steps
         // u * G + c * public_key
-        let point_1 = (GENERATOR_EXTENDED * self.U)
+        let point_1 = (GENERATOR_EXTENDED * self.u)
             + ((public_key_pair.0).0.as_ref() * c);
         // u * G_nums + c * public_key_prime
-        let point_2 = (GENERATOR_NUMS_EXTENDED * self.U)
+        let point_2 = (GENERATOR_NUMS_EXTENDED * self.u)
             + ((public_key_pair.0).1.as_ref() * c);
 
-        point_1.eq(&(self.R.0).0.as_ref()) && point_2.eq(&(self.R.0).1.as_ref())
+        point_1.eq(self.public.R().as_ref())
+            && point_2.eq(self.public.R_prime().as_ref())
     }
 }
 
@@ -147,16 +158,15 @@ impl Serializable<96> for Proof {
 
     fn to_bytes(&self) -> [u8; Self::SIZE] {
         let mut buf = [0u8; Self::SIZE];
-        buf[..32].copy_from_slice(&self.U.to_bytes()[..]);
-        buf[32..].copy_from_slice(&self.R.to_bytes()[..]);
+        buf[..32].copy_from_slice(&self.u.to_bytes()[..]);
+        buf[32..].copy_from_slice(&self.public.to_bytes()[..]);
         buf
     }
 
-    #[allow(non_snake_case)]
     fn from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
-        let U = JubJubScalar::from_slice(&bytes[..32])?;
-        let R = PublicKeyPair::from_slice(&bytes[32..])?;
+        let u = JubJubScalar::from_slice(&bytes[..32])?;
+        let public = PublicKeyPair::from_slice(&bytes[32..])?;
 
-        Ok(Self { U, R })
+        Ok(Self { u, public })
     }
 }

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -34,14 +34,13 @@ fn challenge_hash(R: JubJubExtended, message: BlsScalar) -> JubJubScalar {
 #[derive(PartialEq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 pub struct Signature {
-    U: JubJubScalar,
+    u: JubJubScalar,
     R: JubJubExtended,
 }
 
 impl Signature {
-    #[allow(non_snake_case)]
     pub fn u(&self) -> &JubJubScalar {
-        &self.U
+        &self.u
     }
 
     #[allow(non_snake_case)]
@@ -49,8 +48,8 @@ impl Signature {
         &self.R
     }
 
-    // Signs a chosen message with a given secret key
-    // using the dusk variant of the Schnorr signature scheme.
+    /// Signs a chosen message with a given secret key
+    /// using the dusk variant of the Schnorr signature scheme.
     #[allow(non_snake_case)]
     pub fn new<R>(sk: &SecretKey, rng: &mut R, message: BlsScalar) -> Self
     where
@@ -67,9 +66,9 @@ impl Signature {
         let c = challenge_hash(R, message);
 
         // Compute scalar signature, U = r - c * sk,
-        let U = r - (c * sk.as_ref());
+        let u = r - (c * sk.as_ref());
 
-        Signature { U, R }
+        Signature { u, R }
     }
 
     /// Function to verify that a given point in a Schnorr signature
@@ -80,7 +79,7 @@ impl Signature {
 
         // Compute verification steps
         // u * G + c * public_key
-        let point_1 = (GENERATOR_EXTENDED * self.U) + (public_key.as_ref() * c);
+        let point_1 = (GENERATOR_EXTENDED * self.u) + (public_key.as_ref() * c);
 
         point_1.eq(&self.R)
     }
@@ -91,16 +90,16 @@ impl Serializable<64> for Signature {
 
     fn to_bytes(&self) -> [u8; Self::SIZE] {
         let mut buf = [0u8; Self::SIZE];
-        buf[..32].copy_from_slice(&self.U.to_bytes()[..]);
+        buf[..32].copy_from_slice(&self.u.to_bytes()[..]);
         buf[32..].copy_from_slice(&JubJubAffine::from(self.R).to_bytes()[..]);
         buf
     }
 
     #[allow(non_snake_case)]
     fn from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
-        let U = JubJubScalar::from_slice(&bytes[..32])?;
+        let u = JubJubScalar::from_slice(&bytes[..32])?;
         let R = JubJubExtended::from(JubJubAffine::from_slice(&bytes[32..])?);
 
-        Ok(Self { U, R })
+        Ok(Self { u, R })
     }
 }


### PR DESCRIPTION
Fixes #23 

## [0.4.0] - 2021-01-29

### Added

- `PublicKeyPair` attributes R and R_prime exposed as methods

### Changed

- `PublicKeyPair::R` renamed to `PublicKeyPair::public`
- JubJubScalars renamed from `U` to `u`, as in notation standards