### PR TITLE
Change LazySync by LazyStatic in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ canonical_derive = {version = "0.5", optional = true}
 [dev-dependencies]
 rand = "0.7"
 anyhow = "1.0"
-lazy_static = "1.0"
+lazy_static = "1.4"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ canonical_derive = {version = "0.5", optional = true}
 [dev-dependencies]
 rand = "0.7"
 anyhow = "1.0"
+lazy_static = "1.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Although the idea is nice and it was well done, it was decided that it's
better to not include in the codebase any unstable nightly features if
possible.

Therefore the tests have been re-written in order to use lazy_static.

Resolves: #35