### PR TITLE
canonical: Update to `v0.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `canonical` from `0.5` to `0.6` [#41](https://github.com/dusk-network/schnorr/issues/41)
+
 ## [0.6.0] - 2021-04-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,18 @@ authors = [
 edition = "2018"
 
 [dependencies]
-rand_core = "0.5"
+rand_core = "0.6"
 dusk-bytes = "0.1"
-dusk-bls12_381 = {version = "0.6", default-features = false}
-dusk-jubjub = {version = "0.8", default-features = false}
-dusk-poseidon = {version = "0.20", default-features = false}
-dusk-pki = {version = "0.6", default-features = false}
-dusk-plonk = {version="0.7", optional = true}
-canonical = {version = "0.5", optional = true}
-canonical_derive = {version = "0.5", optional = true}
+dusk-bls12_381 = {version="0.8.0-rc", default-features=false}
+dusk-jubjub = {version="0.10.0-rc", default-features=false}
+dusk-poseidon = {version="0.21.0-rc", default-features=false}
+dusk-pki = {version="0.7.0-rc", default-features=false}
+dusk-plonk = {version="0.8.0-rc", optional=true}
+canonical = {version="0.6", optional=true}
+canonical_derive = {version="0.6", optional=true}
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"
 anyhow = "1.0"
 lazy_static = "1.4"
 

--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_plonk::constraint_system::ecc::scalar_mul::fixed_base;
-use dusk_plonk::constraint_system::ecc::scalar_mul::variable_base::variable_base_scalar_mul;
 use dusk_plonk::constraint_system::ecc::Point;
 use dusk_plonk::jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_plonk::prelude::*;
@@ -28,9 +26,9 @@ pub fn single_key_verify(
     let m = composer.add_witness_to_circuit_description(BlsScalar::zero());
     let c = composer.xor_gate(c_hash, m, 250);
 
-    let p1_l = fixed_base::scalar_mul(composer, u, GENERATOR_EXTENDED);
-    let p1_r = variable_base_scalar_mul(composer, c, PK);
-    let p1 = p1_l.point().add(composer, *p1_r.point());
+    let p1_l = composer.fixed_base_scalar_mul(u, GENERATOR_EXTENDED);
+    let p1_r = composer.variable_base_scalar_mul(c, PK);
+    let p1 = composer.point_addition_gate(p1_l, p1_r);
 
     composer.assert_equal_point(p1, R);
 }
@@ -59,13 +57,13 @@ pub fn double_key_verify(
     let m = composer.add_witness_to_circuit_description(BlsScalar::zero());
     let c = composer.xor_gate(c_hash, m, 250);
 
-    let p1_l = fixed_base::scalar_mul(composer, u, GENERATOR_EXTENDED);
-    let p1_r = variable_base_scalar_mul(composer, c, PK);
-    let p1 = p1_l.point().add(composer, *p1_r.point());
+    let p1_l = composer.fixed_base_scalar_mul(u, GENERATOR_EXTENDED);
+    let p1_r = composer.variable_base_scalar_mul(c, PK);
+    let p1 = composer.point_addition_gate(p1_l, p1_r);
 
-    let p2_l = fixed_base::scalar_mul(composer, u, GENERATOR_NUMS_EXTENDED);
-    let p2_r = variable_base_scalar_mul(composer, c, PK_prime);
-    let p2 = p2_l.point().add(composer, *p2_r.point());
+    let p2_l = composer.fixed_base_scalar_mul(u, GENERATOR_NUMS_EXTENDED);
+    let p2_r = composer.variable_base_scalar_mul(c, PK_prime);
+    let p2 = composer.point_addition_gate(p2_l, p2_r);
 
     composer.assert_equal_point(p1, R);
     composer.assert_equal_point(p2, R_prime);

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -7,10 +7,7 @@
 #![allow(non_snake_case)]
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
-#[allow(unused_imports)]
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -5,8 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};

--- a/tests/zk.rs
+++ b/tests/zk.rs
@@ -11,8 +11,7 @@ mod zk {
     use dusk_pki::{PublicKey, SecretKey};
     use dusk_plonk::circuit;
     use dusk_plonk::circuit::VerifierData;
-    use dusk_plonk::constraint_system::ecc::Point;
-    use dusk_plonk::prelude::Error as PlonkError;
+    use dusk_plonk::error::Error as PlonkError;
     use dusk_plonk::prelude::*;
     use lazy_static;
     use rand::rngs::StdRng;
@@ -233,11 +232,9 @@ mod zk {
             &mut self,
             composer: &mut StandardComposer,
         ) -> Result<(), PlonkError> {
-            let R =
-                Point::from_private_affine(composer, self.signature.R().into());
+            let R = composer.add_affine(self.signature.R().into());
             let u = composer.add_input(self.signature.u().clone().into());
-            let PK =
-                Point::from_private_affine(composer, self.pk.as_ref().into());
+            let PK = composer.add_affine(self.pk.as_ref().into());
             let message = composer.add_input(self.message);
 
             gadgets::single_key_verify(composer, R, u, PK, message);
@@ -285,23 +282,13 @@ mod zk {
             &mut self,
             composer: &mut StandardComposer,
         ) -> Result<(), PlonkError> {
-            let R = Point::from_private_affine(
-                composer,
-                self.proof.keys().R().as_ref().into(),
-            );
-            let R_prime = Point::from_private_affine(
-                composer,
-                self.proof.keys().R_prime().as_ref().into(),
-            );
+            let R = composer.add_affine(self.proof.keys().R().as_ref().into());
+            let R_prime = composer
+                .add_affine(self.proof.keys().R_prime().as_ref().into());
             let u = composer.add_input(self.proof.u().clone().into());
-            let PK = Point::from_private_affine(
-                composer,
-                self.pkp.R().as_ref().into(),
-            );
-            let PK_prime = Point::from_private_affine(
-                composer,
-                self.pkp.R_prime().as_ref().into(),
-            );
+            let PK = composer.add_affine(self.pkp.R().as_ref().into());
+            let PK_prime =
+                composer.add_affine(self.pkp.R_prime().as_ref().into());
             let message = composer.add_input(self.message);
 
             gadgets::double_key_verify(


### PR DESCRIPTION
Canonical 0.6 contains a simplifed interface.

With its update, dusk-plonk brought several API simplifications,
including the ones with the ECC gates.

Resolves #41