### PR TITLE
Update crypto-core dependencies to final versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `canonical` from `0.5` to `0.6` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Update `dusk-plonk` from `0.6` to `0.8` [#41](https://github.com/dusk-network/schnorr/issues/41)
-- Update `dusk-bls12_381` from `0.6` to `0.8` [#41](https://github.com/dusk-network/schnorr/issues/41)
-- Update `dusk-jubjub` from `0.8` to `0.10` [#41](https://github.com/dusk-network/schnorr/issues/41)
-- Update `dusk-poseidon` from `0.18` to `0.21` [#41](https://github.com/dusk-network/schnorr/issues/41)
-- - Update `dusk-pki` from `0.6` to `0.7` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- Update `dusk-poseidon` from `0.18` to `0.21.0-rc` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- Update `dusk-pki` from `0.6` to `0.7` [#41](https://github.com/dusk-network/schnorr/issues/41)
+
+### Removed
+- Remove `dusk-bls12_381` and import it from `dusk-plonk` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- Remove `dusk-jubjub` and import it from `dusk-plonk` [#41](https://github.com/dusk-network/schnorr/issues/41)
 
 ## [0.6.0] - 2021-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update `canonical` from `0.5` to `0.6` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- Update `dusk-plonk` from `0.6` to `0.8` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- Update `dusk-bls12_381` from `0.6` to `0.8` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- Update `dusk-jubjub` from `0.8` to `0.10` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- Update `dusk-poseidon` from `0.18` to `0.21` [#41](https://github.com/dusk-network/schnorr/issues/41)
+- - Update `dusk-pki` from `0.6` to `0.7` [#41](https://github.com/dusk-network/schnorr/issues/41)
 
 ## [0.6.0] - 2021-04-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 rand_core = "0.6"
 dusk-bytes = "0.1"
-dusk-bls12_381 = {version="0.8.0-rc", default-features=false}
-dusk-jubjub = {version="0.10.0-rc", default-features=false}
+dusk-bls12_381 = {version="0.8", default-features=false}
+dusk-jubjub = {version="0.10", default-features=false}
 dusk-poseidon = {version="0.21.0-rc", default-features=false}
 dusk-pki = {version="0.7.0-rc", default-features=false}
-dusk-plonk = {version="0.8.0-rc", optional=true}
+dusk-plonk = {version="0.8", optional=true}
 canonical = {version="0.6", optional=true}
 canonical_derive = {version="0.6", optional=true}
 


### PR DESCRIPTION
The crates are no longer `rc`s and have final versions
published. Therefore we should use them.

Resolves: #45