### PR TITLE
Change crate to be no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `canonical` from `0.5` to `0.6` [#41](https://github.com/dusk-network/schnorr/issues/41)
 
+### Removed
+- Remove `dusk-jubjub` from dependencies [#50](https://github.com/dusk-network/schnorr/issues/50)
+- Remove `dusk-bls12_381` from dependencies [#50](https://github.com/dusk-network/schnorr/issues/50)
+- Remove `anyhow` from dependencies [#50](https://github.com/dusk-network/schnorr/issues/50)
+- Change default crate featureset to be `alloc`. [#50](https://github.com/dusk-network/schnorr/issues/50)
+  
+
 ## [0.6.0] - 2021-04-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = ["alloc"]
 alloc = []
 std = [
   "alloc",
-  "dusk-poseidon/default",
+  "dusk-poseidon/std",
   "dusk-plonk/std"
 ]
 canon = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,32 +10,27 @@ edition = "2018"
 [dependencies]
 rand_core = "0.6"
 dusk-bytes = "0.1"
-dusk-bls12_381 = {version="0.8.0-rc", default-features=false}
-dusk-jubjub = {version="0.10.0-rc", default-features=false}
 dusk-poseidon = {version="0.21.0-rc", default-features=false}
 dusk-pki = {version="0.7.0-rc", default-features=false}
-dusk-plonk = {version="0.8.0-rc", optional=true}
+dusk-plonk = {version="0.8.0-rc", default-features = false, features = ["alloc"]}
 canonical = {version="0.6", optional=true}
 canonical_derive = {version="0.6", optional=true}
 
-
 [dev-dependencies]
 rand = "0.8"
-anyhow = "1.0"
 lazy_static = "1.4"
 
 [features]
-default = ["std"]
+default = ["alloc"]
+alloc = []
 std = [
-    "dusk-bls12_381/default",
-    "dusk-jubjub/default",
-    "dusk-poseidon/default",
-    "dusk-plonk"
+  "alloc",
+  "dusk-poseidon/default",
+  "dusk-plonk/std"
 ]
 canon = [
-    "canonical",
-    "canonical_derive",
-    "dusk-bls12_381/canon",
-    "dusk-jubjub/canon",
-    "dusk-pki/canon"
+  "canonical",
+  "canonical_derive",
+  "dusk-pki/canon",
+  "dusk-plonk/canon"
 ]

--- a/src/key_variants.rs
+++ b/src/key_variants.rs
@@ -4,8 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::JubJubScalar;
+use dusk_plonk::bls12_381::BlsScalar;
+use dusk_plonk::jubjub::JubJubScalar;
 
 pub mod double_key;
 pub mod single_key;

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -8,10 +8,12 @@
 
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
-use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_pki::{PublicKey, SecretKey};
+use dusk_plonk::bls12_381::BlsScalar;
+use dusk_plonk::jubjub::{
+    JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
+};
 use dusk_poseidon::sponge::hash;
 use rand_core::{CryptoRng, RngCore};
 

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -6,12 +6,12 @@
 
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
-use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use dusk_jubjub::{
+use dusk_pki::{PublicKey, SecretKey};
+use dusk_plonk::bls12_381::BlsScalar;
+use dusk_plonk::jubjub::{
     JubJubAffine, JubJubExtended, JubJubScalar, GENERATOR_EXTENDED,
 };
-use dusk_pki::{PublicKey, SecretKey};
 use dusk_poseidon::sponge::hash;
 use rand_core::{CryptoRng, RngCore};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-mod key_variants;
-
-#[cfg(feature = "std")]
 pub mod gadgets;
+mod key_variants;
 
 pub use key_variants::double_key::{Proof, PublicKeyPair};
 pub use key_variants::single_key::Signature;

--- a/tests/double_key_tests.rs
+++ b/tests/double_key_tests.rs
@@ -4,8 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_bls12_381::BlsScalar;
 use dusk_pki::SecretKey;
+use dusk_plonk::bls12_381::BlsScalar;
 use schnorr::{Proof, PublicKeyPair};
 
 #[test]

--- a/tests/single_key_tests.rs
+++ b/tests/single_key_tests.rs
@@ -4,9 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicKey, SecretKey};
+use dusk_plonk::bls12_381::BlsScalar;
 use schnorr::Signature;
 
 #[test]

--- a/tests/zk.rs
+++ b/tests/zk.rs
@@ -4,13 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#[cfg(feature = "std")]
 mod zk {
-    use anyhow::Result;
-    use dusk_jubjub::JubJubAffine;
     use dusk_pki::{PublicKey, SecretKey};
-    use dusk_plonk::circuit;
-    use dusk_plonk::circuit::VerifierData;
     use dusk_plonk::error::Error as PlonkError;
     use dusk_plonk::prelude::*;
     use lazy_static;


### PR DESCRIPTION
Since the crate is no_std, plonk is the only dependency needed
and bls and jubjub are re-exported from it. Therefore don't need
to be imported.

- Remove `dusk-jubjub` from dependencies
- Remove `dusk-bls12_381` from dependencies
- Remove `anyhow` from dependencies
- Change default crate featureset to be `alloc`.

Resolves: #50