### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2021-07-05
+
+### Changed
+- Update poseidon and pki to non-rc versions [#59](https://github.com/dusk-network/schnorr/issues/59)
 
 ## [0.7.0] - 2021-06-02
 
@@ -20,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `dusk-pki` from `0.6` to `0.7` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Change crate name from `schnorr` to `dusk-schnorr` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Change default crate featureset to be `alloc`. [#50](https://github.com/dusk-network/schnorr/issues/50)
+
 ### Removed
 - Remove one hashing level for `message` in signature processing [#55](https://github.com/dusk-network/schnorr/issues/55)
 - Remove `anyhow` from dependencies [#50](https://github.com/dusk-network/schnorr/issues/50)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.7.1"
+version = "0.7.2"
 authors = [
   "Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>",
   "Victor Lopez <victor@dusk.network>", "CPerezz <carlos@dusk.network>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ license = "MPL-2.0"
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
-dusk-poseidon = { version ="0.21.0-rc", default-features = false }
-dusk-pki = { version = "0.7.0-rc", default-features = false}
+dusk-poseidon = { version ="0.21.0", default-features = false }
+dusk-pki = { version = "0.7.0", default-features = false}
 dusk-plonk = { version = "0.8", default-features = false, features = ["alloc"] }
 dusk-bls12_381 = { version = "0.8", default-features = false, features = ["alloc"] }
 dusk-jubjub = { version = "0.10", default-features = false }


### PR DESCRIPTION
## [0.7.2] - 2021-07-05

### Changed
- Update poseidon and pki to non-rc versions [#59](https://github.com/dusk-network/schnorr/issues/59)
