### PR TITLE
Release 0.10

### DIFF
--- a/.github/workflows/dusk_ci.yaml
+++ b/.github/workflows/dusk_ci.yaml
@@ -11,8 +11,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: install
@@ -20,6 +18,18 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: dusk-analyzer
+
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
 
   test_nightly_std:
     name: Nightly tests std
@@ -29,13 +39,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --release
-      
+
   test_nightly_no_std:
     name: Nightly tests no_std
     runs-on: ubuntu-latest
@@ -44,23 +52,32 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --release --no-default-features
-          
-  test_nightly_canon:
-    name: Nightly tests canon
+
+  test_nightly_canon_std:
+    name: Nightly tests canon std
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --features canon
+      
+  test_nightly_canon_no_std:
+    name: Nightly tests canon no_std 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -74,8 +91,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2020-10-25
-          override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,36 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `dusk-pki` from `0.8` to `0.9` [#62](https://github.com/dusk-network/schnorr/issues/62)
-- Update `dusk-plonk` from `0.8` to `0.9` [#62](https://github.com/dusk-network/schnorr/issues/62)
-- Update `dusk-poseidon` from `0.22` to `0.23` [#62](https://github.com/dusk-network/schnorr/issues/62)
+- Update dusk-poseidon from `0.23.0-rc` to `0.25.0-rc`
+- Update dusk-pki from `0.9.0-rc` to `0.10.0-rc`
+- Update dusk-plonk from `0.9` to `0.10`
+- Update dusk-bls12_381 from `0.8` to `0.9`
+- Update dusk-jubjub from `0.10` to `0.11`
+- Update canonical from `0.6` to `0.7`
+- Update canonical_derive from `0.6` to `0.7`
+
+## Fixed
+
+- Fix KeyPair serialization
 
 ## [0.8.0-rc]
 
 ### Changed
 
-- Update `dusk-poseidon` from `0.21` to `0.22.0-rc` [#59](https://github.com/dusk-netwo
-rk/schnorr/issues/59)
-- Update `dusk-pki` from `0.7` to `0.8.0-rc` [#59](https://github.com/dusk-network/schn
-orr/issues/59)
+- Update `dusk-poseidon` from `0.21` to `0.22.0-rc` [#59](https://github.com/dusk-network/schnorr/issues/59)
+- Update `dusk-pki` from `0.7` to `0.8.0-rc` [#59](https://github.com/dusk-network/schnorr/issues/59)
 
 ## [0.7.0] - 2021-06-02
 
 ### Added
+
 - Add `default-features=false` to `rand_core` [#52](https://github.com/dusk-network/schnorr/issues/52)
 
 ### Changed
+
 - Update `canonical` from `0.5` to `0.6` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Update `dusk-plonk` from `0.6` to `0.8` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Update `dusk-poseidon` from `0.18` to `0.21.0-rc` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Update `dusk-pki` from `0.6` to `0.7` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Change crate name from `schnorr` to `dusk-schnorr` [#41](https://github.com/dusk-network/schnorr/issues/41)
 - Change default crate featureset to be `alloc`. [#50](https://github.com/dusk-network/schnorr/issues/50)
+
 ### Removed
+
 - Remove one hashing level for `message` in signature processing [#55](https://github.com/dusk-network/schnorr/issues/55)
 - Remove `anyhow` from dependencies [#50](https://github.com/dusk-network/schnorr/issues/50)
-
-  
 
 ## [0.6.0] - 2021-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `dusk-poseidon` from `0.21` to `0.22.0-rc` [#59](https://github.com/dusk-network/schnorr/issues/59)
-- Update `dusk-pki` from `0.7` to `0.8.0-rc` [#59](https://github.com/dusk-network/schnorr/issues/59)
+- Update `dusk-pki` from `0.8` to `0.9` [#62](https://github.com/dusk-network/schnorr/issues/62)
+- Update `dusk-plonk` from `0.8` to `0.9` [#62](https://github.com/dusk-network/schnorr/issues/62)
+- Update `dusk-poseidon` from `0.22` to `0.23` [#62](https://github.com/dusk-network/schnorr/issues/62)
+
+## [0.8.0-rc]
+
+### Changed
+
+- Update `dusk-poseidon` from `0.21` to `0.22.0-rc` [#59](https://github.com/dusk-netwo
+rk/schnorr/issues/59)
+- Update `dusk-pki` from `0.7` to `0.8.0-rc` [#59](https://github.com/dusk-network/schn
+orr/issues/59)
+
 ## [0.7.0] - 2021-06-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.9.0-rc.1"
+version = "0.10.0-rc.0"
 authors = [
   "Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>",
   "Victor Lopez <victor@dusk.network>", "CPerezz <carlos@dusk.network>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "dusk-schnorr"
-version = "0.8.0-rc.0"
+version = "0.9.0-rc.0"
 authors = [
   "Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>",
   "Victor Lopez <victor@dusk.network>", "CPerezz <carlos@dusk.network>"
 ]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/schnorr"
 keywords = ["cryptography", "schnorr", "zk-snarks", "zero-knowledge", "signatures"]
@@ -21,12 +21,12 @@ license = "MPL-2.0"
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
-dusk-poseidon = { version ="0.22.0-rc", default-features = false }
-dusk-pki = { version = "0.8.0-rc", default-features = false}
-dusk-plonk = { version = "0.8", default-features = false, features = ["alloc"] }
-dusk-bls12_381 = { version = "0.8", default-features = false, features = ["alloc"] }
+dusk-poseidon = { version ="0.23.0-rc", default-features = false }
+dusk-pki = { version = "0.9.0-rc", default-features = false}
+dusk-plonk = { version = "0.9", default-features = false }
+dusk-bls12_381 = { version = "0.8", default-features = false }
 dusk-jubjub = { version = "0.10", default-features = false }
-canonical = { version = "0.6", optional = true}
+canonical = { version = "0.6", optional = true }
 canonical_derive = { version = "0.6", optional = true }
 
 [dev-dependencies]
@@ -34,8 +34,8 @@ rand = "0.8"
 lazy_static = "1.4"
 
 [features]
-default = ["alloc"]
-alloc = []
+default = ["std"]
+alloc = ["dusk-bls12_381/alloc", "dusk-plonk/alloc", "dusk-poseidon/alloc"]
 std = [
   "alloc",
   "dusk-poseidon/std",
@@ -48,3 +48,8 @@ canon = [
   "dusk-pki/canon",
   "dusk-plonk/canon"
 ]
+
+[[test]]
+name = "test-zk"
+path = "tests/zk.rs"
+required-features = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 authors = [
   "Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>",
   "Victor Lopez <victor@dusk.network>", "CPerezz <carlos@dusk.network>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ license = "MPL-2.0"
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
-dusk-poseidon = { version ="0.23.0-rc", default-features = false }
-dusk-pki = { version = "0.9.0-rc", default-features = false}
-dusk-plonk = { version = "0.9", default-features = false }
-dusk-bls12_381 = { version = "0.8", default-features = false }
-dusk-jubjub = { version = "0.10", default-features = false }
-canonical = { version = "0.6", optional = true }
-canonical_derive = { version = "0.6", optional = true }
+dusk-poseidon = { version ="0.25.0-rc", default-features = false }
+dusk-pki = { version = "0.10.0-rc", default-features = false}
+dusk-plonk = { version = "0.10", default-features = false }
+dusk-bls12_381 = { version = "0.9", default-features = false }
+dusk-jubjub = { version = "0.11", default-features = false }
+canonical = { version = "0.7", optional = true }
+canonical_derive = { version = "0.7", optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-10-28

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -8,12 +8,13 @@
 
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
-use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
+use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_pki::{PublicKey, SecretKey};
 use dusk_poseidon::sponge::truncated;
 use rand_core::{CryptoRng, RngCore};
+
+use dusk_plonk::prelude::*;
 
 /// Method to create a challenge hash for signature scheme
 fn challenge_hash(R: PublicKeyPair, message: BlsScalar) -> JubJubScalar {
@@ -144,6 +145,18 @@ impl Proof {
 
         point_1.eq(self.keys.R().as_ref())
             && point_2.eq(self.keys.R_prime().as_ref())
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_witness(
+        &self,
+        composer: &mut TurboComposer,
+    ) -> (Witness, WitnessPoint, WitnessPoint) {
+        let u = composer.append_witness(self.u);
+        let r = composer.append_point(self.keys.R().as_ref());
+        let r_p = composer.append_point(self.keys.R_prime().as_ref());
+
+        (u, r, r_p)
     }
 }
 

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -70,7 +70,7 @@ impl Serializable<64> for PublicKeyPair {
     fn to_bytes(&self) -> [u8; Self::SIZE] {
         let mut buf = [0u8; Self::SIZE];
         buf[..32].copy_from_slice(&(self.0).0.to_bytes()[..]);
-        buf[32..].copy_from_slice(&(self.0).0.to_bytes()[..]);
+        buf[32..].copy_from_slice(&(self.0).1.to_bytes()[..]);
         buf
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,10 @@
 
 #![no_std]
 
-pub mod gadgets;
 mod key_variants;
+
+#[cfg(feature = "alloc")]
+pub mod gadgets;
 
 pub use key_variants::double_key::{Proof, PublicKeyPair};
 pub use key_variants::single_key::Signature;

--- a/tests/double_key.rs
+++ b/tests/double_key.rs
@@ -7,25 +7,31 @@
 use dusk_bls12_381::BlsScalar;
 use dusk_pki::SecretKey;
 use dusk_schnorr::{Proof, PublicKeyPair};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 
 #[test]
 fn proof_verify() {
-    let sk = SecretKey::random(&mut rand::thread_rng());
-    let message = BlsScalar::random(&mut rand::thread_rng());
+    let rng = &mut StdRng::seed_from_u64(2321u64);
+
+    let sk = SecretKey::random(rng);
+    let message = BlsScalar::random(rng);
     let pk_pair: PublicKeyPair = sk.into();
 
-    let proof = Proof::new(&sk, &mut rand::thread_rng(), message);
+    let proof = Proof::new(&sk, rng, message);
 
     assert!(proof.verify(&pk_pair, message));
 }
 
 #[test]
 fn test_wrong_keys() {
-    let sk = SecretKey::random(&mut rand::thread_rng());
-    let wrong_sk = SecretKey::random(&mut rand::thread_rng());
-    let message = BlsScalar::random(&mut rand::thread_rng());
+    let rng = &mut StdRng::seed_from_u64(2321u64);
 
-    let proof = Proof::new(&sk, &mut rand::thread_rng(), message);
+    let sk = SecretKey::random(rng);
+    let wrong_sk = SecretKey::random(rng);
+    let message = BlsScalar::random(rng);
+
+    let proof = Proof::new(&sk, rng, message);
 
     // Derive random public key
     let pk_pair: PublicKeyPair = wrong_sk.into();

--- a/tests/single_key.rs
+++ b/tests/single_key.rs
@@ -8,27 +8,31 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicKey, SecretKey};
 use dusk_schnorr::Signature;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 
 #[test]
-// TestSignVerify
 fn sign_verify() {
-    let sk = SecretKey::random(&mut rand::thread_rng());
-    let message = BlsScalar::random(&mut rand::thread_rng());
+    let rng = &mut StdRng::seed_from_u64(2321u64);
+
+    let sk = SecretKey::random(rng);
+    let message = BlsScalar::random(rng);
     let pk = PublicKey::from(&sk);
 
-    let sig = Signature::new(&sk, &mut rand::thread_rng(), message);
+    let sig = Signature::new(&sk, rng, message);
 
     assert!(sig.verify(&pk, message));
 }
 
 #[test]
-// Test to see failure with random Public Key
 fn test_wrong_keys() {
-    let sk = SecretKey::random(&mut rand::thread_rng());
-    let wrong_sk = SecretKey::random(&mut rand::thread_rng());
-    let message = BlsScalar::random(&mut rand::thread_rng());
+    let rng = &mut StdRng::seed_from_u64(2321u64);
 
-    let sig = Signature::new(&sk, &mut rand::thread_rng(), message);
+    let sk = SecretKey::random(rng);
+    let wrong_sk = SecretKey::random(rng);
+    let message = BlsScalar::random(rng);
+
+    let sig = Signature::new(&sk, rng, message);
 
     // Derive random public key
     let pk = PublicKey::from(&wrong_sk);
@@ -38,9 +42,11 @@ fn test_wrong_keys() {
 
 #[test]
 fn to_from_bytes() {
-    let sk = SecretKey::random(&mut rand::thread_rng());
-    let message = BlsScalar::random(&mut rand::thread_rng());
+    let rng = &mut StdRng::seed_from_u64(2321u64);
 
-    let sig = Signature::new(&sk, &mut rand::thread_rng(), message);
+    let sk = SecretKey::random(rng);
+    let message = BlsScalar::random(rng);
+
+    let sig = Signature::new(&sk, rng, message);
     assert_eq!(sig, Signature::from_bytes(&sig.to_bytes()).unwrap());
 }

--- a/tests/zk.rs
+++ b/tests/zk.rs
@@ -4,317 +4,205 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_pki::{PublicKey, SecretKey};
+use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
+use dusk_pki::SecretKey;
 use dusk_plonk::error::Error as PlonkError;
-use dusk_plonk::prelude::*;
-use dusk_schnorr::{gadgets, Proof, PublicKeyPair, Signature};
+use dusk_schnorr::{gadgets, Proof, Signature};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
-// Static definitions
+use dusk_plonk::prelude::*;
+
 lazy_static::lazy_static! {
-
     pub static ref PP: PublicParameters = {
-        let mut rng = StdRng::seed_from_u64(2321u64);
+        let rng = &mut StdRng::seed_from_u64(2321u64);
 
-        PublicParameters::setup(1 << 13, &mut rng)
+        PublicParameters::setup(1 << 13, rng)
             .expect("Failed to generate PP")
     };
-
-    pub static ref SINGLE: (
-        ProverKey,
-        VerifierData,
-    ) ={
-        let mut rng = StdRng::seed_from_u64(2321u64);
-
-        let (sk, pk, message, signature) = gen_single(&mut rng);
-        let mut circuit = SingleKeyCircuit::new(signature, sk, pk, message);
-
-        circuit.compile(&*PP).unwrap()
-    };
-
-    pub static ref DOUBLE: (
-        ProverKey,
-        VerifierData,
-    ) = {
-        let mut rng = StdRng::seed_from_u64(2321u64);
-
-        let (sk, pk, message, signature) = gen_double(&mut rng);
-        let mut circuit = DoubleKeyCircuit::new(signature, sk, pk, message);
-
-        circuit.compile(&*PP).unwrap()
-    };
-
-    pub static ref SINGLE_PK: ProverKey = SINGLE.0.clone();
-    pub static ref SINGLE_VD: VerifierData = SINGLE.1.clone();
-    pub static ref SINGLE_LB: &'static [u8] = b"single-key-label";
-
-    pub static ref DOUBLE_PK: ProverKey = DOUBLE.0.clone();
-    pub static ref DOUBLE_VD: VerifierData = DOUBLE.1.clone();
-    pub static ref DOUBLE_LB: &'static [u8] = b"double-key-label";
 }
 
 #[test]
-fn single_key_verify() {
-    let mut rng = StdRng::seed_from_u64(2321u64);
-
-    let (sk, pk, message, signature) = gen_single(&mut rng);
-    let mut proof_circuit = SingleKeyCircuit::new(signature, sk, pk, message);
-
-    let proof = proof_circuit
-        .gen_proof(&*PP, &*SINGLE_PK, &SINGLE_LB)
-        .unwrap();
-    let pk: JubJubAffine = pk.as_ref().into();
-    let pi: Vec<PublicInputValue> = vec![pk.into()];
-
-    circuit::verify_proof(
-        &*PP,
-        SINGLE_VD.key(),
-        &proof,
-        &pi,
-        SINGLE_VD.pi_pos(),
-        &SINGLE_LB,
-    )
-    .expect("Failed to verify proof");
-}
-
-#[test]
-fn single_key_verify_wrong_pk() {
-    let mut rng = StdRng::seed_from_u64(2321u64);
-
-    let (sk, pk, message, signature) = gen_single(&mut rng);
-    let mut proof_circuit = SingleKeyCircuit::new(signature, sk, pk, message);
-
-    let proof = proof_circuit
-        .gen_proof(&*PP, &*SINGLE_PK, &SINGLE_LB)
-        .unwrap();
-
-    let (_, pk, _, _) = gen_single(&mut rng);
-    let pk: JubJubAffine = pk.as_ref().into();
-    let pi: Vec<PublicInputValue> = vec![pk.into()];
-
-    let result = circuit::verify_proof(
-        &*PP,
-        SINGLE_VD.key(),
-        &proof,
-        &pi,
-        SINGLE_VD.pi_pos(),
-        &SINGLE_LB,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn double_key_verify() {
-    let mut rng = StdRng::seed_from_u64(2321u64);
-
-    let (sk, pk, message, signature) = gen_double(&mut rng);
-    let mut proof_circuit = DoubleKeyCircuit::new(signature, sk, pk, message);
-
-    let proof = proof_circuit
-        .gen_proof(&*PP, &*DOUBLE_PK, &DOUBLE_LB)
-        .unwrap();
-
-    let pk_prime: JubJubAffine = pk.R_prime().as_ref().into();
-    let pk: JubJubAffine = pk.R().as_ref().into();
-
-    let pi: Vec<PublicInputValue> = vec![pk.into(), pk_prime.into()];
-
-    circuit::verify_proof(
-        &*PP,
-        DOUBLE_VD.key(),
-        &proof,
-        &pi,
-        DOUBLE_VD.pi_pos(),
-        &DOUBLE_LB,
-    )
-    .expect("Failed to verify proof");
-}
-
-#[test]
-fn double_key_verify_wrong_pk() {
-    let mut rng = StdRng::seed_from_u64(2321u64);
-
-    let (sk, pk, message, signature) = gen_double(&mut rng);
-    let mut proof_circuit = DoubleKeyCircuit::new(signature, sk, pk, message);
-
-    let proof = proof_circuit
-        .gen_proof(&*PP, &*DOUBLE_PK, &DOUBLE_LB)
-        .unwrap();
-
-    let pk_prime: JubJubAffine = pk.R_prime().as_ref().into();
-    let (_, pk, _, _) = gen_double(&mut rng);
-    let pk: JubJubAffine = pk.R().as_ref().into();
-
-    let pi: Vec<PublicInputValue> = vec![pk.into(), pk_prime.into()];
-
-    let result = circuit::verify_proof(
-        &*PP,
-        DOUBLE_VD.key(),
-        &proof,
-        &pi,
-        DOUBLE_VD.pi_pos(),
-        &DOUBLE_LB,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn double_key_verify_wrong_pk_prime() {
-    let mut rng = StdRng::seed_from_u64(2321u64);
-
-    let (sk, pk, message, signature) = gen_double(&mut rng);
-    let mut proof_circuit = DoubleKeyCircuit::new(signature, sk, pk, message);
-
-    let proof = proof_circuit
-        .gen_proof(&*PP, &*DOUBLE_PK, &DOUBLE_LB)
-        .unwrap();
-
-    let pk_p: JubJubAffine = pk.R().as_ref().into();
-    let (_, pk, _, _) = gen_double(&mut rng);
-    let pk_prime: JubJubAffine = pk.R_prime().as_ref().into();
-    let pk = pk_p;
-
-    let pi: Vec<PublicInputValue> = vec![pk.into(), pk_prime.into()];
-
-    let result = circuit::verify_proof(
-        &*PP,
-        DOUBLE_VD.key(),
-        &proof,
-        &pi,
-        DOUBLE_VD.pi_pos(),
-        &DOUBLE_LB,
-    );
-    assert!(result.is_err());
-}
-
-#[derive(Debug, Clone)]
-pub struct SingleKeyCircuit {
-    signature: Signature,
-    sk: SecretKey,
-    pk: PublicKey,
-    message: BlsScalar,
-}
-
-impl SingleKeyCircuit {
-    pub fn new(
+fn single_key() {
+    #[derive(Debug)]
+    struct TestSingleKey {
         signature: Signature,
-        sk: SecretKey,
-        pk: PublicKey,
+        k: JubJubExtended,
         message: BlsScalar,
-    ) -> Self {
-        Self {
-            signature,
-            sk,
-            pk,
-            message,
+    }
+
+    impl Default for TestSingleKey {
+        fn default() -> Self {
+            let rng = &mut StdRng::seed_from_u64(0xbeef);
+
+            let sk = SecretKey::random(rng);
+            let message = BlsScalar::random(rng);
+            let signature = Signature::new(&sk, rng, message);
+
+            let k = GENERATOR_EXTENDED * sk.as_ref();
+
+            Self {
+                signature,
+                k,
+                message,
+            }
         }
     }
-}
 
-impl Circuit for SingleKeyCircuit {
-    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
-
-    #[allow(non_snake_case)]
-    fn gadget(
-        &mut self,
-        composer: &mut StandardComposer,
-    ) -> Result<(), PlonkError> {
-        let R = composer.add_affine(self.signature.R().into());
-        let u = composer.add_input((*self.signature.u()).into());
-        let PK = composer.add_affine(self.pk.as_ref().into());
-        let message = composer.add_input(self.message);
-
-        gadgets::single_key_verify(composer, R, u, PK, message);
-
-        let pk = self.pk.as_ref().into();
-        composer.assert_equal_public_point(PK, pk);
-
-        Ok(())
-    }
-
-    fn padded_circuit_size(&self) -> usize {
-        1 << 13
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct DoubleKeyCircuit {
-    proof: Proof,
-    sk: SecretKey,
-    pkp: PublicKeyPair,
-    message: BlsScalar,
-}
-
-impl DoubleKeyCircuit {
-    pub fn new(
-        proof: Proof,
-        sk: SecretKey,
-        pkp: PublicKeyPair,
-        message: BlsScalar,
-    ) -> Self {
-        Self {
-            proof,
-            sk,
-            pkp,
-            message,
+    impl TestSingleKey {
+        pub fn new(
+            signature: Signature,
+            k: JubJubExtended,
+            message: BlsScalar,
+        ) -> Self {
+            Self {
+                signature,
+                k,
+                message,
+            }
         }
     }
-}
 
-impl Circuit for DoubleKeyCircuit {
-    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
+    impl Circuit for TestSingleKey {
+        const CIRCUIT_ID: [u8; 32] = [0xff; 32];
 
-    #[allow(non_snake_case)]
-    fn gadget(
-        &mut self,
-        composer: &mut StandardComposer,
-    ) -> Result<(), PlonkError> {
-        let R = composer.add_affine(self.proof.keys().R().as_ref().into());
-        let R_prime =
-            composer.add_affine(self.proof.keys().R_prime().as_ref().into());
-        let u = composer.add_input((*self.proof.u()).into());
-        let PK = composer.add_affine(self.pkp.R().as_ref().into());
-        let PK_prime = composer.add_affine(self.pkp.R_prime().as_ref().into());
-        let message = composer.add_input(self.message);
+        fn gadget(
+            &mut self,
+            composer: &mut TurboComposer,
+        ) -> Result<(), PlonkError> {
+            let (u, r) = self.signature.to_witness(composer);
 
-        gadgets::double_key_verify(
-            composer, R, R_prime, u, PK, PK_prime, message,
-        );
+            let k = composer.append_point(self.k);
+            let m = composer.append_witness(self.message);
 
-        let pk = self.pkp.R().as_ref().into();
-        composer.assert_equal_public_point(PK, pk);
+            gadgets::single_key_verify(composer, u, r, k, m);
 
-        let pk_prime = self.pkp.R_prime().as_ref().into();
-        composer.assert_equal_public_point(PK_prime, pk_prime);
+            Ok(())
+        }
 
-        Ok(())
+        fn public_inputs(&self) -> Vec<PublicInputValue> {
+            vec![]
+        }
+
+        fn padded_gates(&self) -> usize {
+            1 << 12
+        }
     }
 
-    fn padded_circuit_size(&self) -> usize {
-        1 << 13
-    }
-}
+    let label = b"dusk-network";
 
-pub fn gen_single(
-    rng: &mut StdRng,
-) -> (SecretKey, PublicKey, BlsScalar, Signature) {
+    let rng = &mut StdRng::seed_from_u64(0xfeeb);
+
     let sk = SecretKey::random(rng);
-    let pk = PublicKey::from(&sk);
     let message = BlsScalar::random(rng);
     let signature = Signature::new(&sk, rng, message);
 
-    (sk, pk, message, signature)
+    let k = GENERATOR_EXTENDED * sk.as_ref();
+
+    let (pk, vd) = TestSingleKey::default()
+        .compile(&PP)
+        .expect("Failed to compile circuit");
+
+    let proof = TestSingleKey::new(signature, k, message)
+        .prove(&PP, &pk, label)
+        .expect("Failed to prove");
+
+    TestSingleKey::verify(&PP, &vd, &proof, &[], label)
+        .expect("Failed to verify");
 }
 
-pub fn gen_double(
-    rng: &mut StdRng,
-) -> (SecretKey, PublicKeyPair, BlsScalar, Proof) {
-    let sk = SecretKey::random(rng);
-    let pkp = PublicKeyPair::from(sk);
+#[test]
+fn double_key() {
+    #[derive(Debug)]
+    struct TestDoubleKey {
+        proof: Proof,
+        k: JubJubExtended,
+        k_p: JubJubExtended,
+        message: BlsScalar,
+    }
 
+    impl Default for TestDoubleKey {
+        fn default() -> Self {
+            let rng = &mut StdRng::seed_from_u64(0xbeef);
+
+            let sk = SecretKey::random(rng);
+            let message = BlsScalar::random(rng);
+            let proof = Proof::new(&sk, rng, message);
+
+            let k = GENERATOR_EXTENDED * sk.as_ref();
+            let k_p = GENERATOR_NUMS_EXTENDED * sk.as_ref();
+
+            Self {
+                proof,
+                k,
+                k_p,
+                message,
+            }
+        }
+    }
+
+    impl TestDoubleKey {
+        pub fn new(
+            proof: Proof,
+            k: JubJubExtended,
+            k_p: JubJubExtended,
+            message: BlsScalar,
+        ) -> Self {
+            Self {
+                proof,
+                k,
+                k_p,
+                message,
+            }
+        }
+    }
+
+    impl Circuit for TestDoubleKey {
+        const CIRCUIT_ID: [u8; 32] = [0xff; 32];
+
+        fn gadget(
+            &mut self,
+            composer: &mut TurboComposer,
+        ) -> Result<(), PlonkError> {
+            let (u, r, r_p) = self.proof.to_witness(composer);
+
+            let k = composer.append_point(self.k);
+            let k_p = composer.append_point(self.k_p);
+            let m = composer.append_witness(self.message);
+
+            gadgets::double_key_verify(composer, u, r, r_p, k, k_p, m);
+
+            Ok(())
+        }
+
+        fn public_inputs(&self) -> Vec<PublicInputValue> {
+            vec![]
+        }
+
+        fn padded_gates(&self) -> usize {
+            1 << 13
+        }
+    }
+
+    let label = b"dusk-network";
+
+    let rng = &mut StdRng::seed_from_u64(0xfeeb);
+
+    let sk = SecretKey::random(rng);
     let message = BlsScalar::random(rng);
     let proof = Proof::new(&sk, rng, message);
 
-    (sk, pkp, message, proof)
+    let k = GENERATOR_EXTENDED * sk.as_ref();
+    let k_p = GENERATOR_NUMS_EXTENDED * sk.as_ref();
+
+    let (pk, vd) = TestDoubleKey::default()
+        .compile(&PP)
+        .expect("Failed to compile circuit");
+
+    let proof = TestDoubleKey::new(proof, k, k_p, message)
+        .prove(&PP, &pk, label)
+        .expect("Failed to prove");
+
+    TestDoubleKey::verify(&PP, &vd, &proof, &[], label)
+        .expect("Failed to verify");
 }


### PR DESCRIPTION
- Update dusk-poseidon from `0.23.0-rc` to `0.25.0-rc`
- Update dusk-pki from `0.9.0-rc` to `0.10.0-rc`
- Update dusk-plonk from `0.9` to `0.10`
- Update dusk-bls12_381 from `0.8` to `0.9`
- Update dusk-jubjub from `0.10` to `0.11`
- Update canonical from `0.6` to `0.7`
- Update canonical_derive from `0.6` to `0.7`
- Fix KeyPair serialization
- Bump to `0.10.0-rc.0`
