### PR TITLE
Bump version to `0.11.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2022-10-19
+
 ### Added
 
 - Add support for `rkyv-impl` under `no_std`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
   "Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>",
   "Victor Lopez <victor@dusk.network>", "CPerezz <carlos@dusk.network>"


### PR DESCRIPTION
### Added

- Add support for `rkyv-impl` under `no_std`