### PR TITLE
Bump version to `0.12.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2022-10-27
+
 ### Changed
 
 - Update `dusk-plonk` from `0.12` to `0.13`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.11.1"
+version = "0.12.0"
 authors = [
   "Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>",
   "Victor Lopez <victor@dusk.network>", "CPerezz <carlos@dusk.network>"


### PR DESCRIPTION
### Changed

- Update `dusk-plonk` from `0.12` to `0.13`
- Update `dusk-poseidon` from `0.26` to `0.28`
