### PR TITLE
Derive `Default` for `Signature` and `Proof`

### DIFF
--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -34,7 +34,7 @@ fn challenge_hash(R: PublicKeyPair, message: BlsScalar) -> JubJubScalar {
 }
 
 /// Structure repesenting a pair of [`PublicKey`] generated from a [`SecretKey`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
@@ -89,7 +89,7 @@ impl Serializable<64> for PublicKeyPair {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -28,7 +28,7 @@ fn challenge_hash(R: JubJubExtended, message: BlsScalar) -> JubJubScalar {
 /// An Schnorr signature, produced by signing a message with a
 /// [`SecretKey`].
 #[allow(non_snake_case)]
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(Default, PartialEq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",


### PR DESCRIPTION
`Citadel` requires it for handling the `License` struct.