### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/dusk_ci.yaml
+++ b/.github/workflows/dusk_ci.yaml
@@ -57,32 +57,6 @@ jobs:
           command: test
           args: --release --no-default-features
 
-  test_nightly_canon_std:
-    name: Nightly tests canon std
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features canon
-      
-  test_nightly_canon_no_std:
-    name: Nightly tests canon no_std 
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --no-default-features --features canon
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `dusk-bls12_381` from `0.11` to `0.12`
+- Update `dusk-jubjub` from `0.12` to `0.13`
+- Update `dusk-pki` from `0.12` to `0.13`
+- Update `dusk-poseidon` from `0.30` to `0.31`
+- Update `dusk-plonk` from `0.14` to `0.16`
+
+### Added
+
+- Add `ff` dev-dependency
+
+### Removed
+
+- Remove `canonical` and `canonical_derive` dependencies
+- Remove `canon` feature
+
 ## [0.13.0] - 2023-06-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,11 @@ license = "MPL-2.0"
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
-dusk-poseidon = { version ="0.30", default-features = false }
-dusk-pki = { version = "0.12", default-features = false}
-dusk-plonk = { version = "0.14", default-features = false }
-dusk-bls12_381 = { version = "0.11", default-features = false }
-dusk-jubjub = { version = "0.12", default-features = false }
-canonical = { version = "0.7", optional = true }
-canonical_derive = { version = "0.7", optional = true }
+dusk-poseidon = { version ="0.31", default-features = false }
+dusk-pki = { version = "0.13", default-features = false}
+dusk-plonk = { version = "0.16", default-features = false }
+dusk-bls12_381 = { version = "0.12", default-features = false }
+dusk-jubjub = { version = "0.13", default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 
@@ -36,6 +34,7 @@ rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 criterion = "0.3"
 rand = "0.8"
 lazy_static = "1.4"
+ff = { version = "0.13", default-features = false }
 
 [[bench]]
 name = "schnorr"
@@ -48,12 +47,6 @@ std = [
   "alloc",
   "dusk-plonk/std",
   "rand_core/std"
-]
-canon = [
-  "canonical",
-  "canonical_derive",
-  "dusk-pki/canon",
-  "dusk-plonk/canon"
 ]
 rkyv-impl = [
   "dusk-pki/rkyv-impl",

--- a/src/key_variants/double_key.rs
+++ b/src/key_variants/double_key.rs
@@ -6,8 +6,6 @@
 
 #![allow(non_snake_case)]
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_pki::{PublicKey, SecretKey};
@@ -35,7 +33,6 @@ fn challenge_hash(R: PublicKeyPair, message: BlsScalar) -> JubJubScalar {
 
 /// Structure repesenting a pair of [`PublicKey`] generated from a [`SecretKey`]
 #[derive(Default, Clone, Copy, Debug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
@@ -90,7 +87,6 @@ impl Serializable<64> for PublicKeyPair {
 }
 
 #[derive(Default, Clone, Copy, Debug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),

--- a/src/key_variants/single_key.rs
+++ b/src/key_variants/single_key.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::GENERATOR_EXTENDED;
 use dusk_pki::{PublicKey, SecretKey};
@@ -29,7 +27,6 @@ fn challenge_hash(R: JubJubExtended, message: BlsScalar) -> JubJubScalar {
 /// [`SecretKey`].
 #[allow(non_snake_case)]
 #[derive(Default, PartialEq, Clone, Copy, Debug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),

--- a/tests/double_key.rs
+++ b/tests/double_key.rs
@@ -7,31 +7,32 @@
 use dusk_bls12_381::BlsScalar;
 use dusk_pki::SecretKey;
 use dusk_schnorr::{Proof, PublicKeyPair};
+use ff::Field;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 #[test]
 fn proof_verify() {
-    let rng = &mut StdRng::seed_from_u64(2321u64);
+    let mut rng = StdRng::seed_from_u64(2321u64);
 
-    let sk = SecretKey::random(rng);
-    let message = BlsScalar::random(rng);
+    let sk = SecretKey::random(&mut rng);
+    let message = BlsScalar::random(&mut rng);
     let pk_pair: PublicKeyPair = sk.into();
 
-    let proof = Proof::new(&sk, rng, message);
+    let proof = Proof::new(&sk, &mut rng, message);
 
     assert!(proof.verify(&pk_pair, message));
 }
 
 #[test]
 fn test_wrong_keys() {
-    let rng = &mut StdRng::seed_from_u64(2321u64);
+    let mut rng = StdRng::seed_from_u64(2321u64);
 
-    let sk = SecretKey::random(rng);
-    let wrong_sk = SecretKey::random(rng);
-    let message = BlsScalar::random(rng);
+    let sk = SecretKey::random(&mut rng);
+    let wrong_sk = SecretKey::random(&mut rng);
+    let message = BlsScalar::random(&mut rng);
 
-    let proof = Proof::new(&sk, rng, message);
+    let proof = Proof::new(&sk, &mut rng, message);
 
     // Derive random public key
     let pk_pair: PublicKeyPair = wrong_sk.into();

--- a/tests/single_key.rs
+++ b/tests/single_key.rs
@@ -8,31 +8,32 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicKey, SecretKey};
 use dusk_schnorr::Signature;
+use ff::Field;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 #[test]
 fn sign_verify() {
-    let rng = &mut StdRng::seed_from_u64(2321u64);
+    let mut rng = StdRng::seed_from_u64(2321u64);
 
-    let sk = SecretKey::random(rng);
-    let message = BlsScalar::random(rng);
+    let sk = SecretKey::random(&mut rng);
+    let message = BlsScalar::random(&mut rng);
     let pk = PublicKey::from(&sk);
 
-    let sig = Signature::new(&sk, rng, message);
+    let sig = Signature::new(&sk, &mut rng, message);
 
     assert!(sig.verify(&pk, message));
 }
 
 #[test]
 fn test_wrong_keys() {
-    let rng = &mut StdRng::seed_from_u64(2321u64);
+    let mut rng = StdRng::seed_from_u64(2321u64);
 
-    let sk = SecretKey::random(rng);
-    let wrong_sk = SecretKey::random(rng);
-    let message = BlsScalar::random(rng);
+    let sk = SecretKey::random(&mut rng);
+    let wrong_sk = SecretKey::random(&mut rng);
+    let message = BlsScalar::random(&mut rng);
 
-    let sig = Signature::new(&sk, rng, message);
+    let sig = Signature::new(&sk, &mut rng, message);
 
     // Derive random public key
     let pk = PublicKey::from(&wrong_sk);
@@ -42,11 +43,11 @@ fn test_wrong_keys() {
 
 #[test]
 fn to_from_bytes() {
-    let rng = &mut StdRng::seed_from_u64(2321u64);
+    let mut rng = StdRng::seed_from_u64(2321u64);
 
-    let sk = SecretKey::random(rng);
-    let message = BlsScalar::random(rng);
+    let sk = SecretKey::random(&mut rng);
+    let message = BlsScalar::random(&mut rng);
 
-    let sig = Signature::new(&sk, rng, message);
+    let sig = Signature::new(&sk, &mut rng, message);
     assert_eq!(sig, Signature::from_bytes(&sig.to_bytes()).unwrap());
 }

--- a/tests/zk.rs
+++ b/tests/zk.rs
@@ -8,6 +8,7 @@ use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_pki::SecretKey;
 use dusk_plonk::error::Error as PlonkError;
 use dusk_schnorr::{gadgets, Proof, Signature};
+use ff::Field;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
@@ -33,11 +34,11 @@ fn single_key() {
 
     impl Default for TestSingleKey {
         fn default() -> Self {
-            let rng = &mut StdRng::seed_from_u64(0xbeef);
+            let mut rng = StdRng::seed_from_u64(0xbeef);
 
-            let sk = SecretKey::random(rng);
-            let message = BlsScalar::random(rng);
-            let signature = Signature::new(&sk, rng, message);
+            let sk = SecretKey::random(&mut rng);
+            let message = BlsScalar::random(&mut rng);
+            let signature = Signature::new(&sk, &mut rng, message);
 
             let k = GENERATOR_EXTENDED * sk.as_ref();
 
@@ -81,11 +82,11 @@ fn single_key() {
 
     let label = b"dusk-network";
 
-    let rng = &mut StdRng::seed_from_u64(0xfeeb);
+    let mut rng = StdRng::seed_from_u64(0xfeeb);
 
-    let sk = SecretKey::random(rng);
-    let message = BlsScalar::random(rng);
-    let signature = Signature::new(&sk, rng, message);
+    let sk = SecretKey::random(&mut rng);
+    let message = BlsScalar::random(&mut rng);
+    let signature = Signature::new(&sk, &mut rng, message);
 
     let k = GENERATOR_EXTENDED * sk.as_ref();
     let (prover, verifier) = Compiler::compile::<TestSingleKey>(&PP, label)
@@ -94,7 +95,7 @@ fn single_key() {
     let circuit = TestSingleKey::new(signature, k, message);
 
     let (proof, public_inputs) = prover
-        .prove(rng, &circuit)
+        .prove(&mut rng, &circuit)
         .expect("Proving the circuit should be successful");
 
     verifier
@@ -114,11 +115,11 @@ fn double_key() {
 
     impl Default for TestDoubleKey {
         fn default() -> Self {
-            let rng = &mut StdRng::seed_from_u64(0xbeef);
+            let mut rng = StdRng::seed_from_u64(0xbeef);
 
-            let sk = SecretKey::random(rng);
-            let message = BlsScalar::random(rng);
-            let proof = Proof::new(&sk, rng, message);
+            let sk = SecretKey::random(&mut rng);
+            let message = BlsScalar::random(&mut rng);
+            let proof = Proof::new(&sk, &mut rng, message);
 
             let k = GENERATOR_EXTENDED * sk.as_ref();
             let k_p = GENERATOR_NUMS_EXTENDED * sk.as_ref();
@@ -167,11 +168,11 @@ fn double_key() {
 
     let label = b"dusk-network";
 
-    let rng = &mut StdRng::seed_from_u64(0xfeeb);
+    let mut rng = StdRng::seed_from_u64(0xfeeb);
 
-    let sk = SecretKey::random(rng);
-    let message = BlsScalar::random(rng);
-    let proof = Proof::new(&sk, rng, message);
+    let sk = SecretKey::random(&mut rng);
+    let message = BlsScalar::random(&mut rng);
+    let proof = Proof::new(&sk, &mut rng, message);
 
     let k = GENERATOR_EXTENDED * sk.as_ref();
     let k_p = GENERATOR_NUMS_EXTENDED * sk.as_ref();
@@ -182,7 +183,7 @@ fn double_key() {
     let circuit = TestDoubleKey::new(proof, k, k_p, message);
 
     let (proof, public_inputs) = prover
-        .prove(rng, &circuit)
+        .prove(&mut rng, &circuit)
         .expect("Proving the circuit should succeed");
 
     verifier


### PR DESCRIPTION
- Update `dusk-bls12_381` from `0.11` to `0.12`
- Update `dusk-jubjub` from `0.12` to `0.13`
- Update `dusk-pki` from `0.12` to `0.13`
- Update `dusk-poseidon` from `0.30` to `0.31`
- Update `dusk-plonk` from `0.14` to `0.16`
- Add `ff` dev-dependency
- Remove `canonical` and `canonical_derive` dependencies
- Remove `canon` feature