### PR TITLE
Release `0.16.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2023-11-22
+
 ### Added
 
 - Update README with keys structure [#104]
@@ -234,7 +236,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/dusk-network/schnorr/issues/37
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/schnorr/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/dusk-network/schnorr/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/dusk-network/schnorr/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/dusk-network/schnorr/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/dusk-network/schnorr/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/dusk-network/schnorr/compare/v0.12.1...v0.13.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
   "Luke Pearson <luke@dusk.network>", "zer0 <matteo@dusk.network>",
   "Victor Lopez <victor@dusk.network>", "CPerezz <carlos@dusk.network>"


### PR DESCRIPTION
## [0.16.0] - 2023-11-22

### Added

- Update README with keys structure [#104]
- Add documentation to the new key structs [#105]

### Changed

- Change the NotePublicKey tuple struct to directly be a tuple with two fields [#111]
- Change double and single signature creation to be a method on `NoteSecretKey` [#81]
- Rename internal `key_variants` module to `signatures` [#96]
- Rename the signatures method `to_witness` to `append` [#99]
- Update benchmarks to latest version of plonk [#94]
- Update test structure [#94]
- Move `PublicKeyPair` from `DoubleSignature` to `public_keys` [#95]
- Rename keys: `NoteSecretKey` -> `SecretKey`, `NotePublicKey` -> `PublicKey` [#108]

### Removed

- Hide `(Double)Signature::new()` from the public API [#81]

[0.16.0]: https://github.com/dusk-network/schnorr/compare/v0.15.0...v0.16.0