### PR TITLE
Bump to v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2023-12-13
+
 ### Changed
 
 - Move `verify` method to the public key structs [#81]
@@ -265,7 +267,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/dusk-network/schnorr/issues/37
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/schnorr/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/dusk-network/schnorr/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/dusk-network/schnorr/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/dusk-network/schnorr/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/dusk-network/schnorr/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/dusk-network/schnorr/compare/v0.13.0...v0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/schnorr"


### PR DESCRIPTION
## [0.17.0] - 2023-12-13

### Changed

- Move `verify` method to the public key structs [#81]
- Rename `PublicKeyPair` to `PublicKeyDouble` [#110]
- Rename `sign-single` to `sign` [#110]
- Restructure code internally [#110]
- Rename `DoubleSignature` to `SignatureDouble` [#107]
- Rename gadgets [#107]:
  - `single_key_verify` -> `verify_signature`
  - `double_key_verify` -> `verify_signature_double`
- Replace `HexDebug` trait by `Debug` for `SecretKey` and `PublicKey` [#107]
- Derive `PartialEq` trait instead of implementing it manually [#107]
- Derive `PartialEq` for `PublicKeyDouble` [#107]
- Update `dusk-bls12_381` -> 0.13
- Update `dusk-jubjub` -> 0.14
- Update `dusk-plonk` -> 0.18
- Update `dusk-poseidon` -> 0.32

### Added

- Add `from_raw_unchecked` to `PublicKeyDouble` [#81]
- Add latex documentation of the signature scheme to the README [#110]
- Add `SecretKeyVarGen`, `PublicKeyVarGen` and `SignatureVarGen` [#107]
- Add "double" feature for `SignatureDouble` [#107]
- Add "var_generator" feature for `SignatureVarGen` [#107]
- Add gadget `verify_signature_var_gen` [#107]
- Add `ff` dependency


[0.17.0]: https://github.com/dusk-network/schnorr/compare/v0.16.0...v0.17.0
