### PR TITLE
Bump to v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2024-01-03
+
 ### Changed
 
 - Update `dusk-plonk` -> 0.19
@@ -272,7 +274,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/dusk-network/schnorr/issues/37
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/schnorr/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/dusk-network/schnorr/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/dusk-network/schnorr/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/dusk-network/schnorr/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/dusk-network/schnorr/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/dusk-network/schnorr/compare/v0.14.0...v0.15.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-schnorr"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/schnorr"


### PR DESCRIPTION
## [0.18.0] - 2024-01-03

### Changed

- Update `dusk-plonk` -> 0.19
- Update `dusk-poseidon` -> 0.33



[0.18.0]: https://github.com/dusk-network/schnorr/compare/v0.17.0...v0.18.0
