### PR TITLE
Deprecate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ exclude = [
 ]
 license = "MPL-2.0"
 
+[badges]
+maintanance = { status = "depracated" }
+
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 [![Repository](https://img.shields.io/badge/github-schnorr-blueviolet?logo=github)](https://github.com/dusk-network/schnorr)
 [![Documentation](https://img.shields.io/badge/docs-schnorr-blue?logo=rust)](https://docs.rs/schnorr/)
 
+# Disclaimer
+**This crate is not in active development anymore, use [jubjub-schorr](https://github.com/dusk-network/jubjub-schnorr) instead.**
+
+---
+
 This crate provides a Rust implementation of the Schnorr signature scheme for the JubJub elliptic curve group, using the Poseidon hash function. This implementation is designed by the [Dusk](https://dusk.network) team.
 
 ## About


### PR DESCRIPTION
This crate is not in active development anymore, use [jubjub-schorr](https://github.com/dusk-network/jubjub-schnorr) instead.

Resolves #109 